### PR TITLE
fix: bump marked to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "highlight.js": "^9.15.6",
-    "marked": "^0.6.1"
+    "marked": "^0.8.0"
   },
   "devDependencies": {
     "typedoc": "^0.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,10 +168,10 @@ marked@^0.4.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
   integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
 
-marked@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.1.tgz#a63addde477bca9613028de4b2bc3629e53a0562"
-  integrity sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA==
+marked@^0.8.0:
+  version "0.8.0"
+  resolved "http://artifactory:80/artifactory/api/npm/orion-virtual-npm/marked/-/marked-0.8.0.tgz#ec5c0c9b93878dc52dd54be8d0e524097bd81a99"
+  integrity sha1-7FwMm5OHjcUt1Uvo0OUkCXvYGpk=
 
 minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
marked < 0.7.0 is affected by a regexp DoS.  While that's likely a low
severity for a build-time/documentation project, fixing this up removes
an alert from my build so I figured it'd be good to contribute.

Tested with a Typedoc monorepo, and everything functioned as expected.