### PR TITLE
Resolve module path based on last occurrence

### DIFF
--- a/external-module-map-plugin.ts
+++ b/external-module-map-plugin.ts
@@ -138,7 +138,7 @@ export class ExternalModuleMapPlugin extends ConverterComponent {
       let ref = refsArray
         .filter(ref => ref.name === name)
         .find(ref => path.isAbsolute(ref.originalName)) as ContainerReflection;
-      let root = ref.originalName.replace(new RegExp(`${name}.*`, "gi"), name);
+      let root = ref.originalName.substring(0, ref.originalName.lastIndexOf(name)) + name;
       try {
         // tslint:disable-next-line ban-types
         Object.defineProperty(ref, "kindString", {


### PR DESCRIPTION
I had a bug with this when I had a module name higher up in the path.

Example path: `/example/packages/example/src/index.js`

With this kind of path, when it tries to map `/example/packages/example/src/index.js ==> example` the actual path would be `/example` instead of `/example/packages/example`.

This change fixes that by looking for the last occurrence of name in the path.