### PR TITLE
fix: find README with module reflection only

### DIFF
--- a/external-module-map-plugin.ts
+++ b/external-module-map-plugin.ts
@@ -1,5 +1,3 @@
-import path from "path";
-import fs from "fs";
 import * as ts from "typescript";
 
 import {
@@ -10,7 +8,7 @@ import { Converter } from "typedoc/dist/lib/converter/converter";
 import { Context } from "typedoc/dist/lib/converter/context";
 import { Comment } from "typedoc/dist/lib/models/comments";
 import { Options } from "typedoc/dist/lib/utils/options";
-import { DeclarationReflection } from "typedoc";
+import { DeclarationReflection, ReflectionKind } from "typedoc";
 import { findReadme } from "./find-readme";
 
 interface ModuleRename {
@@ -133,8 +131,9 @@ export class ExternalModuleMapPlugin extends ConverterComponent {
     }
 
     for (const moduleName of this.modules) {
-      const reflection = context.project.findReflectionByName(moduleName);
-
+      const reflection = context.project
+        .getReflectionsByKind(ReflectionKind.Module)
+        .find((ref) => ref.name === moduleName);
       if (!reflection) {
         continue;
       }


### PR DESCRIPTION
As of v0.4.1, if a package name happens to be the same as a parameter name, **No README found for module** error may occur.

## Steps to Reproduce

**package.json**

```json
{
  "private": true,
  "scripts": {
    "typedoc": "typedoc"
  },
  "dependencies": {
    "@strictsoftware/typedoc-plugin-monorepo": "^0.4.1",
    "typedoc": "^0.20.23",
    "typescript": "^4.1.4"
  }
}
```

**tsconfig.json**

```jsonc
{
  "include": [
    "pkg-*/*"
  ],
  "typedocOptions": {
    "entryPoints": ["pkg-a/x.ts", "pkg-b/x.ts"],
    "exclude": ["**/node_modules"],
    "excludeExternals": true,
    "excludePrivate": true,
    "out": "docs",
    "theme": "minimal",
    "plugin": ["@strictsoftware/typedoc-plugin-monorepo"],
    "external-modulemap": "pkg-([^\/]+)\/.*",
  }
}
```

**pkg-a/x.ts**

```ts
export class M {
  constructor(public readonly b: number) {}
}
```

**pkg-a/README.md**

```markdown
# a
```

**pkg-b/x.ts**

```ts
export class M {
  constructor(public readonly c: number) {}
}
```

**pkg-b/README.md**

```markdown
# b
```

**Command line**

```shell
$ npm run typedoc
Info: Loaded plugin @strictsoftware/typedoc-plugin-monorepo
INFO: applying regexp  pkg-([^/]+)/.*  to calculate module names
Mapping "pkg-a/x" to "a"
Mapping "pkg-b/x" to "b"
No README found for module "b"
Rendering [========================================] 100%
Info: Documentation generated at C:\Users\sunny\Documents\code\monorepo-bug\docs
```

## Cause Analysis

I traced into `findReadme` and noticed that it's failing because `reflection.sources?.[0]?.fileName` is *undefined*.
It turns out that `onBeginResolve` function uses this line to locate a *reflection* of the module:

```ts
const reflection = context.project.findReflectionByName(moduleName);
```

In the monorepo shown above, the module name "b" is same as a parameter name, and `findReflectionByName` could return either reflection.
If `findReflectionByName` returns the `ParameterReflection`, it would not have associated `sources` property, and thus this plugin cannot find the README.

## The Fix

This patch ensures the reflection has the proper kind.